### PR TITLE
fix: remove duplicate <title>

### DIFF
--- a/typ/templates/shared.typ
+++ b/typ/templates/shared.typ
@@ -202,7 +202,7 @@
     // set basic document metadata
     set document(
       author: ("Myriad-Dreamin",),
-      title: title,
+      ..if not is-web-target { (title: title) },
     )
 
     // markup setting


### PR DESCRIPTION
There's already a `<title>` in `BaseHead.astro`, if we set document title in `.typ`, there will be another in it's HTML output, which confuses SEO engines and browsers.