### PR TITLE
fix: use `div` instead of `p` for block equations

### DIFF
--- a/typ/templates/shared.typ
+++ b/typ/templates/shared.typ
@@ -85,7 +85,7 @@
       tag: "div",
       theme => {
         set text(fill: theme.main-color)
-        div-frame(attrs: ("class": "block-equation"), it)
+        p-frame(attrs: ("class": "block-equation", "role": "math"), it)
       },
     )
   } else {

--- a/typ/templates/shared.typ
+++ b/typ/templates/shared.typ
@@ -82,10 +82,10 @@
   show math.equation: set text(weight: 400)
   show math.equation.where(block: true): it => context if shiroa-sys-target() == "html" {
     theme-frame(
-      tag: "p",
+      tag: "div",
       theme => {
         set text(fill: theme.main-color)
-        p-frame(attrs: ("class": "block-equation"), it)
+        div-frame(attrs: ("class": "block-equation"), it)
       },
     )
   } else {


### PR DESCRIPTION
Replaced `<p>` elements with `<div>` for block equation containers to prevent invalid nested paragraph tags, which were causing browsers to auto-correct the HTML structure and break the intended structure and function.